### PR TITLE
DailyMed SPL Data Parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Editor settings
+.vscode/
+
+# pycache, compiled files
+__pycache__/
+*.pyc
+
+# Temp data folder
+tempdata/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# fda_data_processor
-Scripts to download in bulk and process the drug labels data from FDA
+# dailymed_data_processor
+Scripts to download in bulk and process the drug labels data from DailyMed.
+
+## TBD
+1. Get history for a set id
+2. Obtain historical label data
+
+## Running the Code
+Requires a minimum python version of `3.6` to run.
+1. `pip3 install -r requirements.txt`
+2. For usage and args, run `python3 main.py -h`
+
+## Code Formatting
+It is recommended to use the [Black Code Formatter](https://github.com/psf/black) which can be installed as a plugin for most IDEs. `pyproject.toml` holds the formatter settings.

--- a/labels/spl.py
+++ b/labels/spl.py
@@ -1,0 +1,115 @@
+import concurrent.futures
+import functools
+import os
+
+import requests
+import xmltodict
+
+from utils.logging import getLogger
+
+_logger = getLogger(__name__)
+
+
+class SplFile:
+    """
+    Used to an SPL index file by its page number at
+    https://dailymed.nlm.nih.gov/dailymed/services/v2/spls.xml?page={page_num}
+    """
+
+    BASE_URL = "https://dailymed.nlm.nih.gov/dailymed/services/v2/spls.xml"
+
+    def __init__(self, page_number):
+        if page_number is None:
+            raise ValueError("Page number is not defined")
+        self.page_number = page_number
+        # Attributes to store processed data
+        self.metadata = {}
+        self.spls = []
+        # Process
+        self.__fetch_and_process()
+
+    def get_max_page_number(self):
+        """Returns the max page number for the SPL index data from the metadata of the
+        processed page.
+
+        Returns:
+            int: max page number for the SPL index data
+        """
+        return int(self.metadata["total_pages"])
+
+    def __fetch_and_process(self):
+        """
+        Fetches the spl file and processes it. The parsed data is stored in the
+        spls attribute.
+        """
+        url = f"{SplFile.BASE_URL}?page={self.page_number}"
+        r = requests.get(url, allow_redirects=True)
+        try:
+            dict_data = xmltodict.parse(r.content)
+            self.metadata = dict_data["spls"]["metadata"]
+            self.spls = dict_data["spls"]["spl"]
+        except Exception as e:
+            _logger.error(
+                f"Unable to parse XML data from file {self.filepath},"
+                f"chunk {self.chunk_num}: {e}"
+            )
+
+
+def get_spls(page_num):
+    return SplFile(page_number=page_num).spls
+
+
+def process_paginated_spls(start_page, num_pages=None):
+    """Fetches index pages in the applicable range, from start_page.
+
+    Args:
+        start_page (int): the page number from which to start downloading the SPL index
+        num_pages (int, optional): the number of pages of the index data to download. If left unset, it will
+                                   download all pages available from the starting page number. Defaults to None.
+
+    Raises:
+        ValueError: When start_date is not set
+        ValueError: When start_date is not int or less than 1
+        ValueError: When num_pages is set but is not a positive integer
+
+    Returns:
+        (list[dict], int): The list of spls processed and the last spl index page number processed
+    """
+    if not start_page:
+        raise ValueError("SPL index start page is not set")
+    if (not isinstance(start_page, int)) or start_page < 1:
+        raise ValueError("SPL index start page must be a positive integer")
+    if num_pages is not None:
+        if num_pages is not None and (
+            not isinstance(num_pages, int) or num_pages < 1
+        ):
+            raise ValueError("SPL index start page must be a positive integer")
+
+    # Get max page number available
+    first_spl_file = SplFile(page_number=1)
+    max_page_number = first_spl_file.get_max_page_number()
+
+    if start_page > max_page_number:
+        # Nothing to process
+        return [], None
+
+    # Set end_page according to max_page_number available and num_pages to download
+    end_page = (
+        max_page_number
+        if num_pages is None
+        else min(start_page + num_pages - 1, max_page_number)
+    )
+
+    # Fetch and process all pages in parallel
+    all_spls = []
+    page_nums = range(start_page, end_page + 1)
+    with concurrent.futures.ProcessPoolExecutor() as executor:
+        for page_num, spls in zip(
+            page_nums,
+            executor.map(get_spls, page_nums),
+        ):
+            _logger.info(f"Processed page {page_num}")
+            all_spls.extend(spls)
+
+    # Return all the spls from the index and the last page number downloaded
+    return all_spls, end_page

--- a/main.py
+++ b/main.py
@@ -1,0 +1,55 @@
+import argparse
+import json
+import os
+
+from labels.spl import process_paginated_spls
+from utils.logging import getLogger
+
+_logger = getLogger("main")
+
+TEMP_DATA_FOLDER = "tempdata"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Process the arguments to the application."
+    )
+    parser.add_argument(
+        "--start_page",
+        type=int,
+        help="The page number at which to start the SPL index data processing",
+    )
+    parser.add_argument(
+        "--num_pages",
+        type=int,
+        help="The number of pages of SPL index data to process",
+    )
+    parser.add_argument(
+        "--write_index_data",
+        action=argparse.BooleanOptionalAction,
+        help="Whether to save the downloaded index data as a json file",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    # Note: For ongoing pipeline, the start_page value can be set based on the
+    # page number that was processed in the last run.
+    args = parse_args()
+    _logger.info(f"Running with args: {args}")
+    all_spls, end_page = process_paginated_spls(
+        start_page=args.start_page, num_pages=args.num_pages
+    )
+
+    # Write data obtained into a json file
+    if args.write_index_data:
+        if not os.path.exists(TEMP_DATA_FOLDER):
+            os.mkdir(TEMP_DATA_FOLDER)
+        with open(
+            os.path.join(
+                TEMP_DATA_FOLDER,
+                f"spl_index_pages_{args.start_page}_to_{end_page}.json",
+            ),
+            "w+",
+        ) as f:
+            f.write(json.dumps(all_spls))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 80

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-dotenv==0.16.0
+requests==2.25.1
+xmltodict==0.12.0

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,0 +1,16 @@
+import logging
+
+_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+
+def getLogger(name):
+    # Set up console log handler
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.INFO)
+    ch.setFormatter(logging.Formatter(_FORMAT))
+
+    # Create logger
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    logger.addHandler(ch)
+    return logger


### PR DESCRIPTION
Code to retrieve and parse the XML SPL index to JSON. This may be a duplicate of with the existing [spl_parser](https://github.com/pharmaDB/spl_parser) NPM module, with the difference that the start page and number of pages can be passed as arguments to the runner (see README), which can be re-used in the ETL pipeline.

#### Next Steps:
1. Process Label History
2. Obtain Historical Labels and Sections