### PR TITLE
Insert label doc only if not exists

### DIFF
--- a/spl/labels.py
+++ b/spl/labels.py
@@ -362,11 +362,16 @@ def process_labels_for_set_id(set_id_history):
             label["application_numbers"] = list(
                 labels.application_numbers_for_setid
             )
-            _mongo_client.upsert(
+            # Insert label if not exists
+            existing = _mongo_client.find(
                 MONGO_COLLECTION_NAME,
                 {"spl_id": label["spl_id"], "set_id": label["set_id"]},
-                label,
             )
+            if not existing.count():
+                _mongo_client.insert(
+                    MONGO_COLLECTION_NAME,
+                    label,
+                )
         return True
     return False
 


### PR DESCRIPTION
Since the label doc is modified downstream by the scoring methods, this change ensures that documents are only inserted and not updated.